### PR TITLE
Fix bug with not having PATH (absolute or relative) in one_spool_text…

### DIFF
--- a/sql/smp360_3a_text_spool.sql
+++ b/sql/smp360_3a_text_spool.sql
@@ -4,7 +4,7 @@ DEF in_filename = '/etc/passwd'
 
 HOS if [ -f /etc/passwd ]; then cat /etc/passwd > ospasswd.txt; fi
 
-DEF one_spool_text_file = 'ospasswd.txt'
+DEF one_spool_text_file = './ospasswd.txt'
 DEF one_spool_text_file_rename = 'Y'
 DEF skip_html = '--'
 DEF skip_text_file = ''


### PR DESCRIPTION
…_file

If no path component is provided in `one_spool_text_file` (either absolute or relative) then `one_spool_text_file_chk` in script **moat369_9f_one_text_file.sql** will not properly parse resulting in `one_spool_text_file_chk=NOK2`

Simply adding `./` to make `one_spool_text_file`  relative fixes issue.